### PR TITLE
few changes to sas7bdat backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
   - pip install --upgrade git+http://github.com/ContinuumIO/datashape
 
   # Install sas7bdat
-  - if [[ $TRAVIS_PYTHON_VERSION != '2.6' ]]; then pip install sas7bdat; fi
+  - pip install sas7bdat
 
   # For bcolz
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then conda install unittest2; fi

--- a/into/backends/tests/test_sas.py
+++ b/into/backends/tests/test_sas.py
@@ -18,49 +18,50 @@ from numpy import dtype
 
 cur_path = os.path.abspath(os.path.dirname(__file__))
 test_path = os.path.join(cur_path, 'airline.sas7bdat')
-
-
-@pytest.yield_fixture
-def sasfile():
-    with SAS7BDAT(test_path) as f:
-        yield f
+sasfile = SAS7BDAT(test_path)
 
 
 columns = ("DATE", "AIR", "mon1", "mon2", "mon3", "mon4", "mon5", "mon6",
            "mon7", "mon8", "mon9", "mon10", "mon11", "mon12", "t", "Lair")
 
+ds = dshape('''var * {DATE: date, AIR: float64, mon1: float64, mon2: float64,
+                      mon3: float64, mon4: float64, mon5: float64,
+                      mon6: float64, mon7: float64, mon8: float64,
+                      mon9: float64, mon10: float64, mon11: float64,
+                      mon12: float64, t: float64, Lair: float64}''')
 
-def test_resource_sas7bdat(sasfile):
+
+def test_resource_sas7bdat():
     assert isinstance(resource(test_path), SAS7BDAT)
 
 
-def test_discover_sas(sasfile):
-    ds = ", ".join(col + ": float64" for col in columns[1:])
-    expected = dshape("var * {DATE: date, " + ds + "}")
-    ans = discover(sasfile)
-    assert discover(sasfile) == expected
+def test_discover_sas():
+    assert discover(sasfile) == ds
 
 
-def test_convert_sas_to_dataframe(sasfile):
-    df = sas_to_DataFrame(sasfile)
-    assert set(df.columns) == set(columns)
-    assert all([df[col].dtype == np.dtype('float64') for col in df.columns
-                if col != 'DATE'])
-    assert df['DATE'].dtype == dtype('O')
+def test_convert_sas_to_dataframe():
+    df = convert(pd.DataFrame, sasfile)
+    assert isinstance(df, pd.DataFrame)
+
+    # pandas doesn't support date
+    expected = str(ds.measure).replace('date', 'datetime')
+
+    assert str(discover(df).measure) == expected
 
 
-def test_convert_sas_to_list(sasfile):
+def test_convert_sas_to_list():
     out = convert(list, sasfile)
     assert isinstance(out, list)
+    assert not any(isinstance(item, str) for item in out[0])  # No header
     assert all(isinstance(ln, list) for ln in out)
 
 
-def test_convert_sas_to_iterator(sasfile):
+def test_convert_sas_to_iterator():
     itr = sas_to_iterator(sasfile)
     assert isinstance(itr, Iterator)
 
 
-def test_append_sas_to_sqlite_round_trip(sasfile):
+def test_append_sas_to_sqlite_round_trip():
     expected = convert(set, sasfile)
 
     with tmpfile('db') as fn:


### PR DESCRIPTION
1.  Allow sas7bdat in py26 (fixed here https://bitbucket.org/jaredhobbs/sas7bdat/pull-request/6/python-26-compatibility-and-iterator-fix/diff )
2.  Don't rely on pytest as heavily (tests can now be run with both pytest and nose)
3.  construct datashape programmatically rather than with strings
4.  dataframe construction respects datetime types
5.  don't mutate skip_header attribute
6.  dataframe construction respects column ordering
